### PR TITLE
Axis.get_index() change

### DIFF
--- a/BINoculars/backends/id03.py
+++ b/BINoculars/backends/id03.py
@@ -35,6 +35,15 @@ class HKProjection(HKLProjection):
     def get_axis_labels(self):
         return 'H', 'K'
 
+class specularangles(backend.ProjectionBase):
+   def project(self, wavelength, UB, gamma, delta, theta, mu, chi, phi):
+       delta,gamma = numpy.meshgrid(delta,gamma)
+       mu = mu * numpy.ones_like(delta)
+       return (gamma - mu , gamma + mu , delta)
+
+   def get_axis_labels(self):
+       return 'g-m','g+m','delta'
+
 class ThetaLProjection(backend.ProjectionBase):
     # arrays: gamma, delta
     # scalars: theta, mu, chi, phi
@@ -360,6 +369,8 @@ class EH1(ID03Input):
         else:
             data = image / mon / transm
 
+        if mon == 0:
+            raise ValueError('Monitor is zero, this results in empty output') 
 
         print 'gamma: {0}, delta: {1}, theta: {2}, mu: {3}'.format(gamma, delta, theta, mu)
 
@@ -400,7 +411,8 @@ class EH2(ID03Input):
         else:
             data = image / mon / transm
 
-
+        if mon == 0:
+            raise ValueError('Monitor is zero, this results in empty output') 
 
         print 'gamma: {0}, delta: {1}, theta: {2}, mu: {3}'.format(gamma, delta, theta, mu)
 

--- a/BINoculars/main.py
+++ b/BINoculars/main.py
@@ -62,13 +62,14 @@ class Main(object):
         else:
             jobs = self.input.generate_jobs(command)
             tokens = self.dispatcher.process_jobs(jobs)
-            result = self.dispatcher.sum(tokens)
-            if result is True:
+            self.result = self.dispatcher.sum(tokens)
+            if self.result is True:
                 pass
-            elif isinstance(result, space.EmptySpace):
+            elif isinstance(self.result, space.EmptySpace):
                 sys.stderr.write('error: output is an empty dataset\n')
             else:
-                self.dispatcher.config.destination.store(result)
+                self.dispatcher.config.destination.store(self.result)
+
             
     def process_job(self, job):
         def generator():


### PR DESCRIPTION
this modification would increase the binsize at the upper and lower boundary: this would avoid some float division errors such as 'ValueError: cannot get indices, values from [0.15, 0.15], axes range [0.15, 0.15]'.