### PR TITLE
Store metadata in space

### DIFF
--- a/BINoculars/backend.py
+++ b/BINoculars/backend.py
@@ -33,6 +33,7 @@ class InputBase(util.ConfigurableObject):
     Note: there is no guarantee that generate_jobs() and process_jobs() will
     be called on the same instance, not even in the same process or on the
     same computer!"""
+
     def parse_config(self, config):
         super(InputBase, self).parse_config(config)
         self.config.target_weight = int(config.pop('target_weight', 0))## approximate number of images per job, only useful when running on the oar cluster
@@ -45,7 +46,7 @@ class InputBase(util.ConfigurableObject):
         """Receives a Job() instance, yields (intensity, args_to_be_sent_to_a_Projection_instance)
 
         Job()s could have been pickle'd and distributed over a cluster"""
-        raise NotImplementedError
+        self.metadata = util.MetaBase('job', job.__dict__)
 
     def get_destination_options(self, command):
         """Receives the same command as generate_jobs(), but returns

--- a/BINoculars/backends/id03.py
+++ b/BINoculars/backends/id03.py
@@ -247,8 +247,9 @@ class ID03Input(backend.InputBase):
                 yield backend.Job(scan=scanno, firstpoint=0, lastpoint=pointcount-1, weight=pointcount)
 
     def process_job(self, job):
+        super(ID03Input, self).process_job(job)
         scan = self.get_scan(job.scan)
-        
+        self.metadict = dict()
         try:
             scanparams = self.get_scan_params(scan) # wavelength, UB
             pointparams = self.get_point_params(scan, job.firstpoint, job.lastpoint) # 2D array of diffractometer angles + mon + transm
@@ -259,6 +260,7 @@ class ID03Input(backend.InputBase):
         except Exception as exc:
             exc.args = errors.addmessage(exc.args, ', An error occured for scan {0} at point {1}. See above for more information'.format(self.dbg_scanno, self.dbg_pointno))
             raise
+        self.metadata.add_section('id03_backend', self.metadict)
 
     def parse_config(self, config):
         super(ID03Input, self).parse_config(config)
@@ -341,6 +343,9 @@ class ID03Input(backend.InputBase):
         else:
             UB = numpy.array(scan.header('G')[2].split(' ')[-9:],dtype=numpy.float)
         wavelength = float(scan.header('G')[1].split(' ')[-1])
+
+        self.metadict['UB'] = UB
+        self.metadict['wavelength'] = wavelength
 
         return wavelength, UB
 

--- a/BINoculars/dispatcher.py
+++ b/BINoculars/dispatcher.py
@@ -20,7 +20,8 @@ class Destination(object):
         if opts is not False:
             self.opts = opts
 
-    def set_config(self, conf):
+    def set_config(self, conf, meta):
+        self.meta = meta
         self.config = conf
 
     def set_tmp_filename(self, filename):
@@ -39,6 +40,7 @@ class Destination(object):
         elif self.type == 'final':
             fn = self.final_filename()
             space.config = self.config
+            space.metadata += self.meta
             space.tofile(fn)
 
     def retrieve(self):

--- a/BINoculars/main.py
+++ b/BINoculars/main.py
@@ -37,8 +37,8 @@ class Main(object):
         spaceconf = self.config.copy()
         metadataconfig = self.config.copy()
         metadataconfig.add_section('command', {'command' : command})
-        self.metadata = util.MetaData()
-        self.metadata.add_dataset(metadataconfig)
+        metadata = util.MetaData()
+        metadata.add_dataset(metadataconfig)
 
         #input from either the configfile or the configsectiongroup is valid
         self.dispatcher = backend.get_dispatcher(config.dispatcher, self, default='local')
@@ -46,7 +46,8 @@ class Main(object):
         self.input = backend.get_input(config.input)
 
         self.dispatcher.config.destination.set_final_options(self.input.get_destination_options(command))
-        self.dispatcher.config.destination.set_config(spaceconf)
+        if command:
+            self.dispatcher.config.destination.set_config(spaceconf, metadata)
         self.run(command)
 
     @classmethod
@@ -82,7 +83,6 @@ class Main(object):
             elif isinstance(self.result, space.EmptySpace):
                 sys.stderr.write('error: output is an empty dataset\n')
             else:
-                self.result.metadata += self.metadata
                 self.dispatcher.config.destination.store(self.result)
 
             

--- a/BINoculars/space.py
+++ b/BINoculars/space.py
@@ -306,13 +306,14 @@ class Space(object):
         contribitions    n-dimensional numpy integer array, number of original datapoints (pixels) per grid point
         dimension        n"""
 
-    def __init__(self, axes, config=None):
+    def __init__(self, axes, config=None, metadata=None):
         if not isinstance(axes, Axes):
             self.axes = Axes(axes)
         else:
             self.axes = axes
 
         self.config = config
+        self.metadata = metadata
         
         self.photons = numpy.zeros([len(ax) for ax in self.axes], order='C')
         self.contributions = numpy.zeros(self.photons.shape, dtype=numpy.uint32, order='C')
@@ -345,9 +346,23 @@ class Space(object):
         else:
             raise TypeError("'{0!r}' is not a util.ConfigFile".format(space))
 
+    @property
+    def metadata(self):
+        """util.ConfigFile instance describing configuration file used to create this Space instance"""
+        return self._metadata
+
+    @metadata.setter
+    def metadata(self, metadata):
+        if isinstance(metadata, util.MetaData):
+            self._metadata = metadata
+        elif not metadata:
+            self._metadata = util.MetaData()
+        else:
+            raise TypeError("'{0!r}' is not a util.MetaData".format(space))
+
     def copy(self):
         """Returns a copy of self. Numpy data is not shared, but the Axes object is."""
-        new = self.__class__(self.axes, self.config)
+        new = self.__class__(self.axes, self.config, self.metadata)
         new.photons[:] = self.photons
         new.contributions[:] = self.contributions
         return new
@@ -367,7 +382,7 @@ class Space(object):
         newaxes = tuple(ax[k] for k, ax in zip(newkey, self.axes) if isinstance(ax[k], Axis))
         if not newaxes:
             return self.photons[newkey] / self.contributions[newkey]
-        newspace = self.__class__(newaxes)
+        newspace = self.__class__(newaxes, self.config, self.metadata)
         newspace.photons = self.photons[newkey].copy()
         newspace.contributions = self.contributions[newkey].copy()
         return newspace
@@ -393,7 +408,7 @@ class Space(object):
         index = self.axes.index(axis)
         newaxes = list(self.axes)
         newaxes.pop(index)
-        newspace = self.__class__(newaxes)
+        newspace = self.__class__(newaxes, self.config, self.metadata)
         newspace.photons = self.photons.sum(axis=index)
         newspace.contributions = self.contributions.sum(axis=index)
 
@@ -462,6 +477,7 @@ class Space(object):
         index = tuple(slice(self_ax.get_index(other_ax.min), self_ax.get_index(other_ax.min) + len(other_ax)) for (self_ax, other_ax) in zip(self.axes, other.axes))
         self.photons[index] += other.photons
         self.contributions[index] += other.contributions
+        self.metadata += other.metadata
         return self
 
     def __sub__(self, other):
@@ -559,7 +575,7 @@ class Space(object):
         if not self.dimension == len(labels):
             raise ValueError('dimension mismatch')
         newindices = list(self.axes.index(label) for label in labels)
-        new = self.__class__(tuple(self.axes[index] for index in newindices))
+        new = self.__class__(tuple(self.axes[index] for index in newindices), self.config, self.metadata)
         new.photons = numpy.transpose(self.photons, axes = newindices)
         new.contributions = numpy.transpose(self.contributions, axes = newindices)
         return new
@@ -621,6 +637,7 @@ class Space(object):
             with util.open_h5py(tmpname, 'w') as fp:
                 self.config.tofile(fp)
                 self.axes.tofile(fp)
+                self.metadata.tofile(fp)
                 fp.create_dataset('counts', self.photons.shape, dtype=self.photons.dtype, compression='gzip').write_direct(self.photons)
                 fp.create_dataset('contributions', self.contributions.shape, dtype=self.contributions.dtype, compression='gzip').write_direct(self.contributions)
 
@@ -634,6 +651,7 @@ class Space(object):
             with util.open_h5py(file, 'r') as fp:
                 axes = Axes.fromfile(fp)
                 config = util.ConfigFile.fromfile(fp)
+                metadata = util.MetaData.fromfile(fp)
                 if key:
                     if len(axes) != len(key):
                         raise ValueError("dimensionality of 'key' does not match dimensionality of Space in HDF5 file {0}".format(file))
@@ -641,7 +659,7 @@ class Space(object):
                     axes = tuple(ax[k] for k, ax in zip(key, axes) if isinstance(k, slice))
                 else:
                     key = Ellipsis
-                space = cls(axes, config)
+                space = cls(axes, config, metadata)
                 try:
                     fp['counts'].read_direct(space.photons, key)
                     fp['contributions'].read_direct(space.contributions, key)

--- a/test/cfg.py
+++ b/test/cfg.py
@@ -11,7 +11,7 @@ class TestCase(unittest.TestCase):
     def test_IO(self):
         self.cfg.totxtfile('test.txt')
         self.cfg.tofile('test.hdf5')
-        BINoculars.util.ConfigFile.fromfile('test.hdf5')
+        print BINoculars.util.ConfigFile.fromfile('test.hdf5')
         self.assertRaises(IOError, BINoculars.util.ConfigFile.fromtxtfile, '')
         self.assertRaises(IOError, BINoculars.util.ConfigFile.fromfile, '')
 

--- a/test/metadata.py
+++ b/test/metadata.py
@@ -36,7 +36,10 @@ class TestCase(unittest.TestCase):
 
         print (space + testspace).metadata
 
-
+        print '--------------------------------------------------------'
+        print metadata
+        print metadata.serialize()
+        print BINoculars.util.MetaData.fromserial(metadata.serialize())
 
     def tearDown(self):
         os.remove('test.hdf5')

--- a/test/metadata.py
+++ b/test/metadata.py
@@ -1,0 +1,48 @@
+import BINoculars.util
+import BINoculars.space
+import os
+import numpy
+
+import unittest
+
+class TestCase(unittest.TestCase):
+    def setUp(self):
+        fn = 'examples/configs/example_config_id03'
+        self.cfg = BINoculars.util.ConfigFile.fromtxtfile(fn)
+
+    def test_IO(self):
+        test = {'string' : 'string', 'numpy.array' : numpy.arange(10),  'list' : range(10), 'tuple' : tuple(range(10))}
+        metasection = BINoculars.util.MetaBase()
+        metasection.add_section('first', test)
+        print metasection
+
+        metadata = BINoculars.util.MetaData()
+        metadata.add_dataset(metasection)
+        metadata.add_dataset(self.cfg)
+
+        metadata.tofile('test.hdf5')
+
+        metadata +=  BINoculars.util.MetaData.fromfile('test.hdf5')
+
+        axis = tuple(BINoculars.space.Axis(0,10,1,label) for label in ['h', 'k', 'l'])
+        axes =  BINoculars.space.Axes(axis)
+        space = BINoculars.space.Space(axes)
+        spacedict = dict(z for z in zip('abcde', range(5)))
+        dataset = BINoculars.util.MetaBase('fromspace', spacedict)
+        space.metadata.add_dataset(dataset)
+
+        space.tofile('test2.hdf5')
+        testspace = BINoculars.space.Space.fromfile('test2.hdf5')
+
+        print (space + testspace).metadata
+
+
+
+    def tearDown(self):
+        os.remove('test.hdf5')
+        os.remove('test2.hdf5')
+   
+if __name__ == '__main__':
+    unittest.main()
+
+


### PR DESCRIPTION
1. Leaves the functionality of configfile intact (results in redundant functions)
2. Able to store information specified in the backend in the space
3. Propagates this information through addition of spaces
4. works with OAR, local and multiprocessing modules
5. Can be completely ignored if wished
6. easy extraction of the information