### PR TITLE
backend fixes (UCCD-tagline, metadata)

### DIFF
--- a/BINoculars/backends/bm25.py
+++ b/BINoculars/backends/bm25.py
@@ -85,6 +85,7 @@ class EDFInput(backend.InputBase):
             yield backend.Job(images=imgs, firstimage=s.start, lastimage=s.stop-1, weight=s.stop-s.start)
 
     def process_job(self, job):
+        super(EDFInput, self).process_job(job)
         images = self.get_images(job.images, job.firstimage, job.lastimage) # iterator!
         
         for image in images:

--- a/BINoculars/backends/id03.py
+++ b/BINoculars/backends/id03.py
@@ -469,7 +469,7 @@ class ID03Input(backend.InputBase):
                 zapscanno = int(scanheaderC[2].split(' ')[-1]) # is different from scanno should be changed in spec!
                 try:
                     uccdtagline = scanheaderC[0]
-                    UCCD = uccdtagline[22:].split(os.sep)
+                    UCCD = os.path.split(uccdtagline.split()[-1]) 
                 except:
                     print 'warning: UCCD tag not found, use imagefolder for proper file specification'
                     UCCD = []

--- a/BINoculars/backends/id03.py
+++ b/BINoculars/backends/id03.py
@@ -488,7 +488,7 @@ class ID03Input(backend.InputBase):
             else:
                 try:
                     uccdtagline = scan.header('UCCD')[0]
-                    UCCD = os.path.dirname(uccdtagline[6:]).split(os.sep)
+                    UCCD = os.path.split(os.path.dirname(uccdtagline.split()[-1]))
                 except:
                     print 'warning: UCCD tag not found, use imagefolder for proper file specification'
                     UCCD = []

--- a/BINoculars/backends/id03_xu.py
+++ b/BINoculars/backends/id03_xu.py
@@ -80,6 +80,7 @@ class ID03Input(backend.InputBase):
                 yield backend.Job(scan=scanno, firstpoint=0, lastpoint=pointcount-1, weight=pointcount)
 
     def process_job(self, job):
+        super(ID03Input, self).process_job(job)
         scan = self.get_scan(job.scan)
         
         scanparams = self.get_scan_params(scan) # wavelength, UB
@@ -146,7 +147,7 @@ class ID03Input(backend.InputBase):
     def get_images(self, scan, first, last, dry_run=False):
         try:
             uccdtagline = scan.header('UCCD')[0]
-            UCCD = os.path.dirname(uccdtagline[6:]).split(os.sep)
+            UCCD = os.path.split(os.path.dirname(uccdtagline.split()[-1]))
         except:
             print 'warning: UCCD tag not found, use imagefolder for proper file specification'
             UCCD = []
@@ -169,7 +170,7 @@ class ID03Input(backend.InputBase):
            except Exception as e:
                raise errors.ConfigError("invalid 'imagefolder' specification '{0}': {1}".format(self.config.imagefolder, e))
        else:
-           imagefolder = os.path.join(UCCD[:-1])
+           imagefolder = os.path.join(*UCCD)
 
        if not os.path.exists(imagefolder):
            raise ValueError("invalid 'imagefolder' specification '{0}'. Path {1} does not exist".format(self.config.imagefolder, imagefolder))

--- a/binoculars.py
+++ b/binoculars.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import sys
 import os

--- a/gui.py
+++ b/gui.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 import sys
 import os
 import glob

--- a/processgui.py
+++ b/processgui.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 """
 BINoculars gui for data processing
 Created on 2015-06-04


### PR DESCRIPTION
1) The UCCD tagline parsing was broken in all backends and should now work again. (I removed hard coded string position things which seemed to be unnecessary ugly)

2) the xrayutilities based backends were broken due to API changes. 
It seems now required to call the *process_job* function of InputBase from the backend since otherwise the required *metadata* attribute does not exist. Note that this is not documented in the example backend, which might need an update in this respect as well.

3) correct shebang lines should be added to all executable python files. I did it for those which are marked executable. one might also need this for *server.py* and *fitaid.py*